### PR TITLE
Enable H2 Console Database

### DIFF
--- a/src/main/java/guru/springframework/spring6webapp/bootstrap/BootstrapData.java
+++ b/src/main/java/guru/springframework/spring6webapp/bootstrap/BootstrapData.java
@@ -54,8 +54,13 @@ public class BootstrapData implements CommandLineRunner {
         final Book noEJBSaved = bookRepository.save(noEJB);
 
         // Create an association between those (two authors and two books)
+        // Adding the Book to the Author
         ericSaved.getBooks().add(dddSaved);
         rodSaved.getBooks().add(noEJBSaved);
+
+        // Adding the Author to the Book
+        dddSaved.getAuthors().add(ericSaved);
+        noEJBSaved.getAuthors().add(rodSaved);
 
         // Create a Publisher
         final Publisher horizonBooks = new Publisher();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
-
+# enable H2 console (in-memory database)
+# find a database URL in the console log and login: http://localhost:8080/h2-console/login.jsp
+spring.h2.console.enabled=true


### PR DESCRIPTION
Enable H2 Console in-memory Database to see the "prototype" of created Tables and its relationships.